### PR TITLE
Add flat GeoJSON properties management due to issue #3 from @tyrasd

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ $ query-overpass --overpass-url http://my.overpass-provider.org/
 
 The default is to use `http://overpass-api.de/api/interpreter`.
 
+You can also flatten each GeoJSON feature, making it more easily processable by other software and tools
+
+```bash
+$ query-overpass --flat-properties true
+```
+
+The default is to use `false` to keep the same behaviour as previous version.
+
+Any other string than `true` (case insensitive) provided to `--flat-properties` will make the command use `false`.
+
 ## usage
 
 Installation is easy with npm:
@@ -68,4 +78,7 @@ callback(error, data)
 Where error is an object containing `message` and `statusCode` if an error occured, or `undefined` if
 no error occured. `data` will be the query response as an GeoJSON object.
 
-The only option supported at the moment is `overpassUrl`, which will default to `'http://overpass-api.de/api/interpreter'` unless specified.
+The options supported at the moment are:
+
+* `overpassUrl`, which will default to `'http://overpass-api.de/api/interpreter'` unless specified.
+* `flatProperties`, which will default to `false` unless specified to `true`.

--- a/README.md
+++ b/README.md
@@ -48,12 +48,10 @@ The default is to use `http://overpass-api.de/api/interpreter`.
 You can also flatten each GeoJSON feature, making it more easily processable by other software and tools
 
 ```bash
-$ query-overpass --flat-properties true
+$ query-overpass --flat-properties
 ```
 
-The default is to use `false` to keep the same behaviour as previous version.
-
-Any other string than `true` (case insensitive) provided to `--flat-properties` will make the command use `false`.
+The default behaviour, without adding `--flat-properties` is to use `false` to be consistent with previous version.
 
 ## usage
 
@@ -78,7 +76,4 @@ callback(error, data)
 Where error is an object containing `message` and `statusCode` if an error occured, or `undefined` if
 no error occured. `data` will be the query response as an GeoJSON object.
 
-The options supported at the moment are:
-
-* `overpassUrl`, which will default to `'http://overpass-api.de/api/interpreter'` unless specified.
-* `flatProperties`, which will default to `false` unless specified to `true`.
+The only option supported at the moment is `overpassUrl`, which will default to `'http://overpass-api.de/api/interpreter'` unless specified.

--- a/README.md
+++ b/README.md
@@ -76,4 +76,7 @@ callback(error, data)
 Where error is an object containing `message` and `statusCode` if an error occured, or `undefined` if
 no error occured. `data` will be the query response as an GeoJSON object.
 
-The only option supported at the moment is `overpassUrl`, which will default to `'http://overpass-api.de/api/interpreter'` unless specified.
+The options supported at the moment are
+
+* `overpassUrl`, which will default to `'http://overpass-api.de/api/interpreter'` unless specified.
+* `flatProperties` which will default to `false`.

--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 
 var concat = require('concat-stream'),
-    argv = require('minimist')(process.argv.slice(2)),
+    argv = require('minimist')(process.argv.slice(2), {
+        string: 'overpass-url',
+        boolean: 'flat-properties',
+        default: {
+            'flat-properties': false
+        }
+    }),
     fs = require('fs'),
     overpass = require('./');
 

--- a/cli.js
+++ b/cli.js
@@ -14,7 +14,8 @@ function openData(s) {
             console.log(err);
         }
     }, {
-        overpassUrl: argv['overpass-url']
+        overpassUrl: argv['overpass-url'],
+        flatProperties: argv['flat-properties']
     });
 }
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function(query, cb, options) {
 
         if (!error && response.statusCode === 200) {
             geojson = osmtogeojson(JSON.parse(body), {
-                flatProperties: options.flatProperties
+                flatProperties: options.flatProperties || false
             });
             cb(undefined, geojson);
         } else if (error) {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ module.exports = function(query, cb, options) {
         var geojson;
 
         if (!error && response.statusCode === 200) {
-            geojson = osmtogeojson(JSON.parse(body));
+            geojson = osmtogeojson(JSON.parse(body), {
+                flatProperties: (options.flatProperties != undefined && options.flatProperties.toLowerCase() == 'true' ? true: false)
+            });
             cb(undefined, geojson);
         } else if (error) {
             cb(error);

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function(query, cb, options) {
 
         if (!error && response.statusCode === 200) {
             geojson = osmtogeojson(JSON.parse(body), {
-                flatProperties: (options.flatProperties != undefined && options.flatProperties.toLowerCase() == 'true' ? true: false)
+                flatProperties: options.flatProperties
             });
             cb(undefined, geojson);
         } else if (error) {


### PR DESCRIPTION
The modification have been done in `cli.js`, `index.js` and also in the documentation `README.md`

As I used the ternary operator in the `index.js` file, you may want to use a variable if you feel it's too lengthy.

Thanks for your feedback and also this library.