### PR TITLE
pass request object back from call

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var osmtogeojson = require('osmtogeojson'),
 
 module.exports = function(query, cb, options) {
     options = options || {};
-    request.post(options.overpassUrl || 'http://overpass-api.de/api/interpreter', function (error, response, body) {
+    return request.post(options.overpassUrl || 'http://overpass-api.de/api/interpreter', function (error, response, body) {
         var geojson;
 
         if (!error && response.statusCode === 200) {

--- a/test/specs.js
+++ b/test/specs.js
@@ -2,7 +2,7 @@ var test = require('tape'),
     queryOverpass = require('../');
 
 test('can execute basic query', function(t) {
-    queryOverpass('[out:json];node(57.7,11.9,57.8,12.0)[amenity=bar];out;', function(err, geojson) {
+    var req = queryOverpass('[out:json];node(57.7,11.9,57.8,12.0)[amenity=bar];out;', function(err, geojson) {
         if (err) {
             return t.fail(err);
         }
@@ -13,6 +13,9 @@ test('can execute basic query', function(t) {
 
         var f = geojson.features[0];
         t.ok(f.properties && f.properties.tags, 'Properties are not flattened');
+
+        t.ok(req.path, 'Should return request object');
+
         t.end();
     });
 });


### PR DESCRIPTION
This will enable ending a request before it finishes. In my case when I move or zoom a map I want to abort the pending request and start a new one.