### PR TITLE
Swap out request module for xhr when using browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
 var osmtogeojson = require('osmtogeojson'),
+    querystring = require('querystring'),
     request = require('request');
 
 module.exports = function(query, cb, options) {
     options = options || {};
-    return request.post(options.overpassUrl || 'http://overpass-api.de/api/interpreter', function (error, response, body) {
+    var reqOptions = {
+        body: querystring.stringify({ data: query })
+    };
+    return request.post(options.overpassUrl || 'http://overpass-api.de/api/interpreter', reqOptions, function (error, response, body) {
         var geojson;
 
         if (!error && response.statusCode === 200) {
@@ -23,7 +27,5 @@ module.exports = function(query, cb, options) {
                 message: 'Unknown error.',
             });
         }
-    }).form({
-        data: query
     });
 };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var osmtogeojson = require('osmtogeojson'),
 module.exports = function(query, cb, options) {
     options = options || {};
     var reqOptions = {
+        headers: {
+            'content-type': 'application/x-www-form-urlencoded'
+        },
         body: querystring.stringify({ data: query })
     };
     return request.post(options.overpassUrl || 'http://overpass-api.de/api/interpreter', reqOptions, function (error, response, body) {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "test": "tape test/*.js | faucet"
   },
+  "browser": {
+    "request": "xhr"
+  },
   "bin": {
     "query-overpass": "cli.js"
   },
@@ -21,7 +24,8 @@
     "concat-stream": "^1.6.0",
     "minimist": "^1.2.0",
     "osmtogeojson": "^2.2.12",
-    "request": "^2.81.0"
+    "request": "^2.81.0",
+    "xhr": "^2.4.0"
   },
   "devDependencies": {
     "faucet": "0.0.1",


### PR DESCRIPTION
This PR tells query-overpass to use the [`xhr`](https://www.npmjs.com/package/xhr) module instead of `request` when bundling for the browser using `browserify`. The browserified bundle size is reduced from 356KB to 12KB. The request module is still used when run in Node.

In order to work with the `xhr` module, I had to remove the unsupported `form` method. The `form` method in `request` is a [wrapper function](https://github.com/request/request/blob/master/request.js#L1247-L1256) that sets the content-type header and encodes the query string. This PR sets the header and query string via the `options` object that is passed to `request` and `xhr`.